### PR TITLE
Fix issues reported by yamllint in README + fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ routes:
 _SNIProxy_ has a built-in ACL logic and can block and allow connections based on
 the client IP address. When at least one range is explicitly allowed, all other
 ranges are automatically denied (0.0.0.0/0 & ::/0). When an address can be found
-it two ranges, the most specific wins. If the exact same range is both allowed
+in two ranges, the most specific wins. If the exact same range is both allowed
 and denied, the deny rule wins.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -40,48 +40,51 @@ _SNIProxy_'s configuration file is written in the
 [YAML](https://en.wikipedia.org/wiki/YAML) format.
 
 ```text
+---
 bind_https: <address:port to bind to for HTTPS requests (default: "[::]:443)">
 bind_http: <address:port to bind to for HTTP requests (default: "[::]:80)">
 routes:
-- domains:
-  - <domain to match in the SNI>
-  - <domain to match in the SNI>
-  backend:
-    address: <address:port of the backend; address can be a resolvable hostname>
-    proxy_protocol: <optional; HAProxy protocol version (1 or 2)>
-  alpn_challenge_backend:
-    address: <optional; address:port for the ALPN challenge backend>
-    proxy_protocol: <optional; HAProxy protocol version (1 or 2)>
-  alpn_challenge_bypass_acl: <optional; boolean>
-  denied_ranges:
-  - <optional; ip/cidr range to block>
-  - <optional; ip/cidr range to block>
-  allowed_ranges:
-  - <optional; ip/cidr range to allow>
-- domains:
-  ...
+  - domains:
+      - <domain to match in the SNI>
+      - <domain to match in the SNI>
+    backend:
+      address: <address:port of the backend; address can be a resolvable hostname>
+      proxy_protocol: <optional; HAProxy protocol version (1 or 2)>
+    alpn_challenge_backend:
+      address: <optional; address:port for the ALPN challenge backend>
+      proxy_protocol: <optional; HAProxy protocol version (1 or 2)>
+    alpn_challenge_bypass_acl: <optional; boolean>
+    denied_ranges:
+      - <optional; ip/cidr range to block>
+      - <optional; ip/cidr range to block>
+    allowed_ranges:
+      - <optional; ip/cidr range to allow>
+  - domains:
+    ...
 ```
 
 A configuration for a single route can be as simple as:
 
 ```yaml
+---
 routes:
-- domains:
-  - "example.net"
-  backend:
-    address: "1.2.3.4:443"
+  - domains:
+      - "example.net"
+    backend:
+      address: "1.2.3.4:443"
 ```
 
 Domain names can be a regular expression:
 
 ```yaml
+---
 routes:
-- domains:
-  # Matches example.net and all its subdomains.
-  - "example.net"
-  - "*.example.net"
-  backend:
-    address: "1.2.3.4:443"
+  - domains:
+      # Matches example.net and all its subdomains.
+      - "example.net"
+      - "*.example.net"
+    backend:
+      address: "1.2.3.4:443"
 ```
 
 ### Optional parameters
@@ -93,63 +96,67 @@ it two ranges, the most specific wins. If the exact same range is both allowed
 and denied, the deny rule wins.
 
 ```yaml
+---
 routes:
-- domains:
-  - "example.net"
-  backend:
-    address: "1.2.3.4:8080"
-  denied_ranges:
-    - "10.0.0.42/32"
-- domains:
-  - "foo.example.com"
-  backend:
-    address: "5.6.7.8:443"
-  denied_ranges:
-  - "10.0.0.42/32"
-  - "10.0.0.43/32"
-  - "192.168.0.0/24"
-  allowed_ranges:
-  - "192.168.0.42/32"
+  - domains:
+      - "example.net"
+    backend:
+      address: "1.2.3.4:8080"
+    denied_ranges:
+      - "10.0.0.42/32"
+  - domains:
+      - "foo.example.com"
+    backend:
+      address: "5.6.7.8:443"
+    denied_ranges:
+      - "10.0.0.42/32"
+      - "10.0.0.43/32"
+      - "192.168.0.0/24"
+    allowed_ranges:
+      - "192.168.0.42/32"
 ```
 
 _SNIProxy_ can use a different backend for ALPN requests:
 
 ```yaml
+---
 routes:
-- domains:
-  - "example.net"
-  backend:
-    address: "[1111::1]:8080"
-  alpn_challenge_backend:
-    address: "alpn-backend:8080"
+  - domains:
+      - "example.net"
+    backend:
+      address: "[1111::1]:8080"
+    alpn_challenge_backend:
+      address: "alpn-backend:8080"
 ```
 
 The ACL rules can be bypassed for ALPN challenge requests:
 
 ```yaml
+---
 routes:
-- domains:
-  - "example.net"
-  backend:
-    address: "[1111::1]:8080"
-  alpn_challenge_backend:
-    address: "alpn-backend:8080"
-  alpn_challenge_bypass_acl: true
-  allowed_ranges:
-  - "192.168.0.0/24"
+  - domains:
+      - "example.net"
+    backend:
+      address: "[1111::1]:8080"
+    alpn_challenge_backend:
+      address: "alpn-backend:8080"
+    alpn_challenge_bypass_acl: true
+    allowed_ranges:
+      - "192.168.0.0/24"
 ```
 
 [HAProxy PROXY protocol](https://www.haproxy.org/download/2.0/doc/proxy-protocol.txt)
 v1 and v2 are supported for backend connections:
 
 ```yaml
+---
 routes:
-- domains:
-  - "example.net"
-  backend:
-    address: "[1111::1]:8080"
-    proxy_protocol: 2
-  alpn_challenge_backend:
-    address: "alpn-backend:8080"
-    proxy_protocol: 1
+  - domains:
+      - "example.net"
+    backend:
+      address: "[1111::1]:8080"
+      proxy_protocol: 2
+    alpn_challenge_backend:
+      address: "alpn-backend:8080"
+      proxy_protocol: 1
 ```


### PR DESCRIPTION
This fixes a few indentation issues reported by yamllint in the examples provided in the README.md, as well as add the `---` string at the beginning of each yaml snippet, as suggested by yamllint.

Finally, fix a small typo in text.