### PR TITLE
tls: allow extension size of zero for session_ticket

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -65,9 +65,9 @@ impl Tls {
                 );
             }
 
-            // Extension is empty.
-            if len == 0 {
-                bail!("Invalid extension: len is null");
+            // Extension is empty, can happen e.g. on session_ticket
+            if size == 0 {
+                continue;
             }
 
             // Read the extension data. Even if we do not support the extension, we can't seek as


### PR DESCRIPTION
used by Mbed TLS 2.28.8

From RFC 5077:
   Note that the encoding of an empty SessionTicket extension was
   ambiguous in RFC 4507.  An RFC 4507 implementation may have encoded
   it as:

        00 23      Extension type 35
        00 02      Length of extension contents
        00 00      Length of ticket

   or it may have encoded it the same way as this update:

        00 23      Extension type 35
        00 00      Length of extension contents

   A server wishing to support RFC 4507 clients should respond to an
   empty SessionTicket extension encoded the same way as it received it.