### PR TITLE
cargo: update edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "sniproxy"
 license = "GPL-2.0+"
 authors = ["Antoine Tenart <antoine.tenart@ack.tf>"]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Update edition to 2024, this allows to use if let chains, and similar features, that got introduced with edition 2024.

I intend to use if-let chains in a nat46 feature, similar as https://github.com/AGWA/snid implements it